### PR TITLE
Add range reverse

### DIFF
--- a/packages/array/README.md
+++ b/packages/array/README.md
@@ -4,8 +4,29 @@ Utility package for handling arrays.
 
 ## Usage
 
+First, import the `@proem/array` module is imported into the namespace
+
 ```
 import array from '@proem/array';
+```
 
-// TODO: DEMONSTRATE API
+`@proem/array` provides custom implementations for convenience functions already implemented by the `Array.prototype`, such as the `map` function. The semantics might differ, for example the `array.map` in proem trades the support of sparse arrays for performance.
+
+```
+const input = [1, 2, 3, 4, 5]
+
+const output = array.map(input, n => n + 1)  // [2, 3, 4, 5, 6, 7]
+```
+
+Some functions have their partially applicable counterparts. For example, proem provides the `array.map.partial`, which returns a function applicable to arrays.
+
+```
+const a = ["a,", "b", "c"]
+const b = ["d", "e", "f"]
+
+const partial = map.partial((str: string) => str.toUpperCase())
+
+const output = partial(a) // [ 'A,', 'B', 'C' ]
+
+const otherOutput = partial(b) // ['D', 'E', 'F']
 ```

--- a/packages/array/src/array.test.ts
+++ b/packages/array/src/array.test.ts
@@ -59,7 +59,7 @@ describe('reduce', () => {
   })
 })
 
-describe(find.name, () => {
+describe('find', () => {
   it('should find first item that matches predicate', () => {
     const items = [
       { kind: 'a', value: 1 },

--- a/packages/array/src/array.test.ts
+++ b/packages/array/src/array.test.ts
@@ -1,4 +1,4 @@
-import { map, filter, reduce, reverse, find } from './index'
+import { map, filter, find, range, reduce, reverse } from './index'
 
 describe('map', () => {
   it('should transform items', () => {
@@ -93,5 +93,27 @@ describe('reverse', () => {
     const items = [1, 2, 3, 4]
     const result = reverse(items)
     expect(items).toEqual([1, 2, 3, 4])
+  })
+})
+
+describe('range', () => {
+  it('should return [0] for range(0, 0)', () => {
+    const result = range(0, 0)
+    expect(result).toEqual([0])
+  })
+
+  it('should fill an array with [1,2,3] with range(1, 3)', () => {
+    const result = range(1, 3)
+    expect(result).toEqual([1, 2, 3])
+  })
+
+  it('should fill an array with [1] with range(1, 1)', () => {
+    const result = range(1, 3)
+    expect(result).toEqual([1, 2, 3])
+  })
+
+  it('should return an empty array where a < b when called with range(a, b)', () => {
+    const result = range(2, 1)
+    expect(result).toEqual([])
   })
 })

--- a/packages/array/src/array.test.ts
+++ b/packages/array/src/array.test.ts
@@ -1,4 +1,4 @@
-import { map, filter, reduce, find } from './index'
+import { map, filter, reduce, reverse, find } from './index'
 
 describe('map', () => {
   it('should transform items', () => {
@@ -74,5 +74,24 @@ describe(find.name, () => {
     const items = [1, 2, 3, 4]
     const result = find(items, i => i > 4)
     expect(result).toBeUndefined()
+  })
+})
+
+describe('reverse', () => {
+  it('returns an empty array for empty arrays', () => {
+    const result = reverse([])
+    expect(result).toEqual([])
+  })
+
+  it('return a reversed array', () => {
+    const items = [1, 2, 3, 4]
+    const result = reverse(items)
+    expect(result).toEqual([4, 3, 2, 1])
+  })
+
+  it('should not mutate the input array', () => {
+    const items = [1, 2, 3, 4]
+    const result = reverse(items)
+    expect(items).toEqual([1, 2, 3, 4])
   })
 })

--- a/packages/array/src/index.ts
+++ b/packages/array/src/index.ts
@@ -80,3 +80,12 @@ export const find = <A>(
 
 find.partial = <A>(predicate: IndexedPredicate<A>) => (array: A[]) =>
   find(array, predicate)
+
+export function reverse<A>(array: A[]) {
+  const result = new Array<A>(array.length)
+  for (let i = 0; i < array.length; i++) {
+    const target = array.length - i - 1
+    result[target] = array[i]
+  }
+  return result
+}

--- a/packages/array/src/index.ts
+++ b/packages/array/src/index.ts
@@ -89,3 +89,18 @@ export function reverse<A>(array: A[]) {
   }
   return result
 }
+
+export function range(from: number, to: number): number[] {
+  if (to < from) {
+    return []
+  }
+  if (from === to) {
+    return [from]
+  }
+  const result = new Array<number>(to - from)
+  for (let i = 0; i < to; i++) {
+    const n = from + i
+    result[i] = n
+  }
+  return result
+}


### PR DESCRIPTION
Adds functions for generating a reversed immutable copy of an array and a range

The range works as one would expect, `range(1, 3)` yields an array `[1, 2, 3]` The function copies it's semantics from Haskell, where the rules described by the unit tests apply. Note that the function does not take an array as a parameter, so it's signature is different from other functions in the module.