### PR TITLE
Adds dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,5 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "live"


### PR DESCRIPTION
Dependabot is a service to keep a repositories dependencies up-to-date with PR's

Docs: https://dependabot.com/docs/config-file/