### PR TITLE
Set npmClient=yarn in lerna.json

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,6 @@
   "packages": [
     "packages/*"
   ],
+  "npmClient": "yarn",
   "version": "0.0.23"
 }


### PR DESCRIPTION
This is so that "lerna bootstrap" uses `yarn` instead of defaulting to `npm`.